### PR TITLE
Add Support for PY3.10; Fix downloadtest.py

### DIFF
--- a/udger/base.py
+++ b/udger/base.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    from collections import MutableMapping
+except ImportError:
+    from collections.abc import MutableMapping
 import os
 import re
 import socket
@@ -30,7 +33,7 @@ class cached_property(object):
         return res
 
 
-class LRUDict(collections.MutableMapping):
+class LRUDict(MutableMapping):
     def __init__(self, maxlen, *a, **k):
         self.maxlen = maxlen
         self.d = dict(*a, **k)

--- a/udger/tests/downloadtest.py
+++ b/udger/tests/downloadtest.py
@@ -1,4 +1,4 @@
-from udger import UdgerDownloader
+from udger.downloader import UdgerDownloader
 
 downloader = UdgerDownloader('test_data')
 downloader.download()


### PR DESCRIPTION
This PR Fixes the import for `MutableMapping` since that was moved in Python 3.10 to allow this library to be used with Python 3.10. I also fixed the broken import in `tests/downloadtest.py`, which makes that work now.

This seemingly works, despite `tests/runtests.py` returning inconsistencies because I don't have access to the original Udger DB that the `test_ip.json` and `test_ua.json` are basing their results on. There's probably an opportunity here to completely refactor the tests to be based on PyTest or Unittests or something a bit more "standard" within the python community and supply the original data, but I did not pursue that in this PR. So I'm somewhat reliant on the fact that this did load the DB and, by and large, pulled data from the DB without issue.